### PR TITLE
Adjust chase camera defaults and reset smoothing on mode switch

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/CameraController.client.lua.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/CameraController.client.lua.client.lua
@@ -143,7 +143,8 @@ end
 -- ===== Manual toggles =====
 local useCockpitManual = false
 local controllerEnabled = true   -- K: toggelt onze writer
-local frontChase = true          -- F: wissel front/back chase (default AAN voor jouw test)
+local frontChase = false         -- F: wissel front/back chase (default: achtervolg-view)
+local resetSmoothing             -- forward declare zodat we 'm vanuit toggles kunnen aanroepen
 UIS.InputBegan:Connect(function(input, gp)
 	if gp then return end
 	if input.KeyCode == Enum.KeyCode.V then
@@ -151,10 +152,11 @@ UIS.InputBegan:Connect(function(input, gp)
 	elseif input.KeyCode == Enum.KeyCode.K then
 		controllerEnabled = not controllerEnabled
 		print("[CamGuard] controllerEnabled=", controllerEnabled)
-	elseif input.KeyCode == Enum.KeyCode.F then
-		frontChase = not frontChase
-		print("[Cam] chase mode =", frontChase and "FRONT" or "BACK")
-	end
+        elseif input.KeyCode == Enum.KeyCode.F then
+                frontChase = not frontChase
+                if resetSmoothing then resetSmoothing() end -- voorkom smoothing-blend tussen front/back
+                print("[Cam] chase mode =", frontChase and "FRONT" or "BACK")
+        end
 end)
 
 -- ===== Tuning =====
@@ -199,9 +201,9 @@ local smoothPos, smoothLook = nil, nil
 local lastCycle             = nil
 local clipArmed             = false
 
-local function resetSmoothing()
-	smoothPos, smoothLook = nil, nil
-	clipArmed = false
+resetSmoothing = function()
+        smoothPos, smoothLook = nil, nil
+        clipArmed = false
 end
 Players.LocalPlayer.CharacterAdded:Connect(resetSmoothing)
 RoundActiveVal:GetPropertyChangedSignal("Value"):Connect(resetSmoothing)


### PR DESCRIPTION
## Summary
- default the chase camera to the behind-follow view so players immediately look forward when a round starts
- clear the camera smoothing cache whenever the chase mode is toggled to avoid blending front and back views

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d7ffa11dac8322bbfd63d58a121e1d