### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent instructions for `roblox-neonriders`
+
+- This repository mirrors a Roblox experience using Rojo. Preserve the existing directory layout and file naming because it maps directly to Roblox services.
+- Code is written in Luau. Prefer tabs for indentation (Roblox Studio default) and keep statement layout similar to existing files.
+- When adding configuration or documentation, keep comments in English or Dutch as appropriate for surrounding content.
+- Avoid introducing external tooling without confirming it can run inside Roblox Studio.

--- a/src/ServerScriptService/AGENTS.md
+++ b/src/ServerScriptService/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent instructions for `src/ServerScriptService`
+
+- Server scripts live here with the double `.server.lua.server.lua` suffix so that both Rojo and Roblox Studio keep the correct ServerScriptService classification. Keep that suffix when adding new server scripts.
+- Prefer descriptive PascalCase names that match their Roblox instances (e.g. `GameServer`).
+- RemoteEvent names must stay in sync with the values created in `ReplicatedStorage`; avoid renaming without updating clients.

--- a/src/StarterGui/AGENTS.md
+++ b/src/StarterGui/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent instructions for `src/StarterGui`
+
+- Each folder maps to a ScreenGui or UI component. Keep file and instance names aligned.
+- Local scripts must keep the `.client.lua` suffix so they remain LocalScripts when synced.
+- UI logic should avoid direct waits for `ReplicatedStorage` objects; rely on events exposed by the server code instead.

--- a/src/StarterPlayer/AGENTS.md
+++ b/src/StarterPlayer/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent instructions for `src/StarterPlayer`
+
+- Keep client scripts inside the Roblox-standard subfolders (e.g. `StarterPlayerScripts`).
+- Preserve `.client.lua` suffixes for LocalScripts so that Rojo exports them correctly.
+- Avoid heavy server logic here; limit to player-specific input and camera control.


### PR DESCRIPTION
## Summary
- document repository-wide conventions in a new AGENTS.md
- add directory-specific guidance for ServerScriptService, StarterGui, and StarterPlayer assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d821baf0088322be70b6ad635f0caf