### PR TITLE
Add toggle for snap turning

### DIFF
--- a/src/ServerScriptService/GameServer.server.lua.server.lua
+++ b/src/ServerScriptService/GameServer.server.lua.server.lua
@@ -25,6 +25,7 @@ local SpawnFolder    = Workspace:WaitForChild("SpawnPoints")
 local TICK_DT         = 1/30
 local TURN_RATE       = math.rad(140)
 local TURN_THRESH     = 0.20
+local SNAP_TURN       = math.rad(90)
 
 local WALL_THICK      = 0.2
 local WALL_HEIGHT     = 10
@@ -61,6 +62,13 @@ end
 
 local function fwdFromYaw(yaw)
 	return (CFrame.Angles(0, yaw, 0)).LookVector
+end
+
+local function round(n)
+	if n >= 0 then
+		return math.floor(n + 0.5)
+	end
+	return math.ceil(n - 0.5)
 end
 
 local function orientSpawn(cframe)
@@ -276,7 +284,22 @@ end
 -- Input
 TurnEvent.OnServerEvent:Connect(function(plr, steer)
 	local c = cycles[plr]
-	if c and c.running then
+	if not (c and c.running) then return end
+
+	local steerType = typeof(steer)
+	if steerType == "table" then
+		local snap = steer.snap or steer.Snap
+		local dir = math.clamp(tonumber(snap) or 0, -1, 1)
+		if dir ~= 0 then
+			local yaw = c.yaw or 0
+			local base = round(yaw / SNAP_TURN) * SNAP_TURN
+			c.yaw = base + dir * SNAP_TURN
+			c.steer = 0
+			if c.model and c.model.PrimaryPart then
+				c.model:PivotTo(CFrame.new(c.pos) * CFrame.Angles(0, c.yaw, 0))
+			end
+		end
+	else
 		c.steer = math.clamp(tonumber(steer) or 0, -1, 1)
 	end
 end)

--- a/src/StarterPlayer/StarterPlayerScripts/ClientControls.client.lua.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/ClientControls.client.lua.client.lua
@@ -19,6 +19,7 @@ CAS:BindActionAtPriority("BlockJump", blockJump, false, 999999, Enum.KeyCode.Spa
 -- === Besturing ===
 local running = false
 local steer, leftDown, rightDown = 0, false, false
+local useSnapTurns = false
 local function setSteer()
 	if leftDown and not rightDown then steer = -1
 	elseif rightDown and not leftDown then steer = 1
@@ -26,20 +27,56 @@ local function setSteer()
 end
 
 UIS.InputBegan:Connect(function(i,gp)
-	if gp or not running then return end
-	if i.KeyCode == Enum.KeyCode.A or i.KeyCode == Enum.KeyCode.Left  then leftDown = true end
-	if i.KeyCode == Enum.KeyCode.D or i.KeyCode == Enum.KeyCode.Right then rightDown = true end
-	setSteer()
+        if gp then return end
+
+        if i.KeyCode == Enum.KeyCode.T then
+                useSnapTurns = not useSnapTurns
+                leftDown, rightDown = false, false
+                steer = 0
+
+                if not useSnapTurns then
+                        if UIS:IsKeyDown(Enum.KeyCode.A) or UIS:IsKeyDown(Enum.KeyCode.Left) then
+                                leftDown = true
+                        end
+                        if UIS:IsKeyDown(Enum.KeyCode.D) or UIS:IsKeyDown(Enum.KeyCode.Right) then
+                                rightDown = true
+                        end
+                        setSteer()
+                end
+
+                if running then
+                        TurnEvent:FireServer(0)
+                end
+                return
+        end
+
+        if not running then return end
+
+        if useSnapTurns then
+                if i.KeyCode == Enum.KeyCode.A or i.KeyCode == Enum.KeyCode.Left then
+                        TurnEvent:FireServer({ snap = -1 })
+                elseif i.KeyCode == Enum.KeyCode.D or i.KeyCode == Enum.KeyCode.Right then
+                        TurnEvent:FireServer({ snap = 1 })
+                end
+                return
+        end
+
+        if i.KeyCode == Enum.KeyCode.A or i.KeyCode == Enum.KeyCode.Left  then leftDown = true end
+        if i.KeyCode == Enum.KeyCode.D or i.KeyCode == Enum.KeyCode.Right then rightDown = true end
+        setSteer()
 end)
 UIS.InputEnded:Connect(function(i,gp)
-	if gp or not running then return end
-	if i.KeyCode == Enum.KeyCode.A or i.KeyCode == Enum.KeyCode.Left  then leftDown = false end
-	if i.KeyCode == Enum.KeyCode.D or i.KeyCode == Enum.KeyCode.Right then rightDown = false end
-	setSteer()
+        if gp or not running then return end
+        if useSnapTurns then return end
+        if i.KeyCode == Enum.KeyCode.A or i.KeyCode == Enum.KeyCode.Left  then leftDown = false end
+        if i.KeyCode == Enum.KeyCode.D or i.KeyCode == Enum.KeyCode.Right then rightDown = false end
+        setSteer()
 end)
 
 RunService.RenderStepped:Connect(function()
-	if running then TurnEvent:FireServer(steer) end
+        if running and not useSnapTurns then
+                TurnEvent:FireServer(steer)
+        end
 end)
 
 -- === Countdown HUD ===


### PR DESCRIPTION
## Summary
- add a T key toggle so players can switch between smooth steering and 90° snap turns
- update the turn handling on the server to apply discrete 90° rotations when requested

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d82523388c8322b545374942755941