### PR TITLE
Implement vehicle seat driving controls

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -2,6 +2,11 @@
   "name": "project",
   "tree": {
     "$className": "DataModel",
+    "ReplicatedStorage": {
+      "$className": "ReplicatedStorage",
+      "$ignoreUnknownInstances": true,
+      "$path": "src/ReplicatedStorage"
+    },
     "ServerScriptService": {
       "$className": "ServerScriptService",
       "$ignoreUnknownInstances": true,

--- a/src/ReplicatedStorage/Remotes/VehicleInput.meta.json
+++ b/src/ReplicatedStorage/Remotes/VehicleInput.meta.json
@@ -1,0 +1,3 @@
+{
+  "className": "RemoteEvent"
+}

--- a/src/ReplicatedStorage/Remotes/init.meta.json
+++ b/src/ReplicatedStorage/Remotes/init.meta.json
@@ -1,0 +1,4 @@
+{
+  "className": "Folder",
+  "ignoreUnknownInstances": true
+}

--- a/src/ServerScriptService/ReplicatedRemotes.server.lua.server.lua
+++ b/src/ServerScriptService/ReplicatedRemotes.server.lua.server.lua
@@ -1,0 +1,15 @@
+local RS = game:GetService("ReplicatedStorage")
+
+local remotes = RS:FindFirstChild("Remotes")
+if not remotes then
+	remotes = Instance.new("Folder")
+	remotes.Name = "Remotes"
+	remotes.Parent = RS
+end
+
+local vehicleInput = remotes:FindFirstChild("VehicleInput")
+if not vehicleInput then
+	vehicleInput = Instance.new("RemoteEvent")
+	vehicleInput.Name = "VehicleInput"
+	vehicleInput.Parent = remotes
+end

--- a/src/ServerScriptService/ReplicatedRemotes.server.lua.server.lua
+++ b/src/ServerScriptService/ReplicatedRemotes.server.lua.server.lua
@@ -1,15 +1,12 @@
+-- File: ServerScriptService/ReplicatedRemotes.server.lua
+-- Zorgt dat ReplicatedStorage.Remotes.VehicleInput bestaat (voorkomt je "OnServerEvent?" spam).
 local RS = game:GetService("ReplicatedStorage")
-
-local remotes = RS:FindFirstChild("Remotes")
-if not remotes then
-	remotes = Instance.new("Folder")
-	remotes.Name = "Remotes"
-	remotes.Parent = RS
+local rem = RS:FindFirstChild("Remotes") or Instance.new("Folder")
+rem.Name = "Remotes"; rem.Parent = RS
+if not rem:FindFirstChild("VehicleInput") then
+	local ev = Instance.new("RemoteEvent")
+	ev.Name = "VehicleInput"
+	ev.Parent = rem
 end
-
-local vehicleInput = remotes:FindFirstChild("VehicleInput")
-if not vehicleInput then
-	vehicleInput = Instance.new("RemoteEvent")
-	vehicleInput.Name = "VehicleInput"
-	vehicleInput.Parent = remotes
-end
+-- Optionele no-op handler zodat clientcalls nooit in de wachtrij blijven hangen:
+rem.VehicleInput.OnServerEvent:Connect(function() end)  -- stilhouden

--- a/src/ServerScriptService/SeatAutoAlignAndDrive.server.lua
+++ b/src/ServerScriptService/SeatAutoAlignAndDrive.server.lua
@@ -1,0 +1,81 @@
+-- File: ServerScriptService/SeatAutoAlignAndDrive.server.lua
+-- 1) Zet elke (Vehicle)Seat bij instappen vooruit gelijk aan het voertuig (geen Studio-handwerk nodig).
+-- 2) Maakt de assembly non-anchored en geeft network ownership aan de bestuurder.
+-- 3) Als het een VehicleSeat is: leest Throttle/Steer en duwt simpel vooruit + yaw.
+
+local Players = game:GetService("Players")
+
+local FWD_SPEED    = 80   -- studs/s
+local TURN_FACTOR  = 2
+
+local function getModelFromSeat(seat)
+	if not seat then return nil end
+	local m = seat:FindFirstAncestorOfClass("Model")
+	if not m then return nil end
+	if not m.PrimaryPart then
+		for _,d in ipairs(m:GetDescendants()) do
+			if d:IsA("BasePart") then m.PrimaryPart = d; break end
+		end
+	end
+	return m
+end
+
+local function unanchorAll(model)
+	for _,d in ipairs(model:GetDescendants()) do
+		if d:IsA("BasePart") then d.Anchored = false end
+	end
+end
+
+local function setOwner(model, plr)
+	if model and model.PrimaryPart and model.PrimaryPart.CanSetNetworkOwnership then
+		model.PrimaryPart:SetNetworkOwner(plr)  -- nil = server
+	end
+end
+
+local function alignSeatToModelFront(seat, model)
+	if not (seat and model and model.PrimaryPart) then return end
+	seat.CFrame = CFrame.new(seat.Position, seat.Position + model.PrimaryPart.CFrame.LookVector)
+end
+
+local function applyDrive(model, throttle, steer)
+	if not (model and model.PrimaryPart) then return end
+	local root = model.PrimaryPart
+	local f = root.CFrame.LookVector * (FWD_SPEED * throttle)
+	root.AssemblyLinearVelocity = Vector3.new(f.X, root.AssemblyLinearVelocity.Y, f.Z)
+	root:ApplyAngularImpulse(Vector3.new(0, steer * TURN_FACTOR * root.AssemblyMass, 0))
+end
+
+local function attachSeat(seat)
+	seat:GetPropertyChangedSignal("Occupant"):Connect(function()
+		local hum = seat.Occupant
+		if hum and hum.Parent then
+			local plr = Players:GetPlayerFromCharacter(hum.Parent)
+			local model = getModelFromSeat(seat)
+			if plr and model then
+				alignSeatToModelFront(seat, model)   -- altijd goed vooruit
+				unanchorAll(model)                   -- ownership kan niet op anchored/welded-to-anchored
+				setOwner(model, plr)
+			end
+		else
+			local model = getModelFromSeat(seat)
+			if model then setOwner(model, nil) end
+		end
+	end)
+
+	if seat:IsA("VehicleSeat") then
+		seat:GetPropertyChangedSignal("Throttle"):Connect(function()
+			applyDrive(getModelFromSeat(seat), seat.Throttle, seat.Steer)
+		end)
+		seat:GetPropertyChangedSignal("Steer"):Connect(function()
+			applyDrive(getModelFromSeat(seat), seat.Throttle, seat.Steer)
+		end)
+	end
+end
+
+-- Hook alle huidige + toekomstige seats (Seat én VehicleSeat)
+for _,inst in ipairs(workspace:GetDescendants()) do
+	if inst:IsA("Seat") then attachSeat(inst) end
+end
+workspace.DescendantAdded:Connect(function(inst)
+	if inst:IsA("Seat") then attachSeat(inst) end
+end)

--- a/src/ServerScriptService/SeatFrontAssert.server.lua.server.lua
+++ b/src/ServerScriptService/SeatFrontAssert.server.lua.server.lua
@@ -1,0 +1,29 @@
+-- File: ServerScriptService/SeatFrontAssert.server.lua
+
+-- (Optioneel) Console-check om verkeerde seat-oriëntatie snel te detecteren.
+
+local function dot(a, b) return a.X*b.X + a.Y*b.Y + a.Z*b.Z end
+
+for _, seat in ipairs(workspace:GetDescendants()) do
+	if seat:IsA("VehicleSeat") then
+		local model = seat:FindFirstAncestorOfClass("Model")
+		if model and model.PrimaryPart then
+			local d = dot(seat.CFrame.LookVector, model.PrimaryPart.CFrame.LookVector)
+			if d < 0.5 then
+				warn(("[SeatFrontAssert] '%s': seat-front wijkt af van vehicle-front (dot=%.2f). Roteer de VehicleSeat."):format(model.Name, d))
+			end
+		end
+	end
+end
+
+workspace.DescendantAdded:Connect(function(inst)
+	if inst:IsA("VehicleSeat") then
+		local model = inst:FindFirstAncestorOfClass("Model")
+		if model and model.PrimaryPart then
+			local d = dot(inst.CFrame.LookVector, model.PrimaryPart.CFrame.LookVector)
+			if d < 0.5 then
+				warn(("[SeatFrontAssert] '%s': seat-front wijkt af van vehicle-front (dot=%.2f). Roteer de VehicleSeat."):format(model.Name, d))
+			end
+		end
+	end
+end)

--- a/src/ServerScriptService/TrailWall.server.lua
+++ b/src/ServerScriptService/TrailWall.server.lua
@@ -1,0 +1,96 @@
+-- File: ServerScriptService/TrailWall.server.lua
+-- Bouwt een "Tron-muur" achter elk voertuig met een (Vehicle)Seat zodra iemand instapt.
+
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+
+-- Tune
+local WALL_HEIGHT       = 10
+local WALL_THICKNESS    = 1
+local MIN_SEG_LEN       = 6        -- elke ~6 studs een segment
+local COLOR             = Color3.fromRGB(0, 255, 255)
+
+-- Per bestuurder: {model=Model, seat=Seat, lastPos=Vector3, baseY=number}
+local active = {}
+
+local function getModelFromSeat(seat: Instance): Model?
+	if not seat then return nil end
+	local m = seat:FindFirstAncestorOfClass("Model")
+	if not m then return nil end
+	if not m.PrimaryPart then
+		-- kies eerste BasePart als PrimaryPart
+		for _,d in ipairs(m:GetDescendants()) do
+			if d:IsA("BasePart") then m.PrimaryPart = d; break end
+		end
+	end
+	return m
+end
+
+local function createSegment(p0: Vector3, p1: Vector3, baseY: number)
+	-- Center + lengte over XZ; hou Y vast (muur op vaste hoogte)
+	local mid = Vector3.new( (p0.X+p1.X)/2, baseY + WALL_HEIGHT/2, (p0.Z+p1.Z)/2 )
+	local lookAt = Vector3.new(p1.X, mid.Y, p1.Z)
+	local len = (Vector3.new(p1.X, 0, p1.Z) - Vector3.new(p0.X, 0, p0.Z)).Magnitude
+	if len < 0.001 then return end
+
+	local part = Instance.new("Part")
+	part.Anchored = true
+	part.CanCollide = true
+	part.Material = Enum.Material.Neon
+	part.Color = COLOR
+	part.Size = Vector3.new(WALL_THICKNESS, WALL_HEIGHT, len)
+	part.CFrame = CFrame.lookAt(mid, lookAt)  -- Z-as = lengte langs rijrichting. :contentReference[oaicite:1]{index=1}
+	part.Name = "LightWall"
+	part.Parent = workspace
+end
+
+-- start/stop bij zitten
+local function attachSeat(seat: Seat)
+	seat:GetPropertyChangedSignal("Occupant"):Connect(function()
+		local hum = seat.Occupant
+		if hum and hum.Parent then
+			local plr = Players:GetPlayerFromCharacter(hum.Parent)
+			local model = getModelFromSeat(seat)
+			if not (plr and model and model.PrimaryPart) then return end
+
+			-- muur-basishoogte: onderkant seat (muur "uit de vloer")
+			local baseY = (seat.Position.Y - seat.Size.Y/2)
+
+			active[plr] = {
+				model = model,
+				seat  = seat,
+				lastPos = Vector3.new(model.PrimaryPart.Position.X, 0, model.PrimaryPart.Position.Z),
+				baseY = baseY
+			}
+		else
+			-- stop muur
+			for plr, rec in pairs(active) do
+				if rec.seat == seat then active[plr] = nil end
+			end
+		end
+	end)
+end
+
+-- hook alle bestaande en toekomstige seats
+for _,inst in ipairs(workspace:GetDescendants()) do
+	if inst:IsA("Seat") then attachSeat(inst) end
+end
+workspace.DescendantAdded:Connect(function(inst)
+	if inst:IsA("Seat") then attachSeat(inst) end
+end)
+
+-- teken muur-segmenten
+RunService.Heartbeat:Connect(function()
+	for plr, rec in pairs(active) do
+		local model = rec.model
+		if not (model and model.PrimaryPart and rec.seat.Parent) then
+			active[plr] = nil
+		else
+			local cur = Vector3.new(model.PrimaryPart.Position.X, 0, model.PrimaryPart.Position.Z)
+			if (cur - rec.lastPos).Magnitude >= MIN_SEG_LEN then
+				createSegment(rec.lastPos, cur, rec.baseY)
+				rec.lastPos = cur
+			end
+		end
+	end
+end)

--- a/src/ServerScriptService/VehicleController.server.lua.server.lua
+++ b/src/ServerScriptService/VehicleController.server.lua.server.lua
@@ -1,39 +1,72 @@
+local Players = game:GetService("Players")
 local RS = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+local Workspace = game:GetService("Workspace")
 
-local REMOTES = RS:FindFirstChild("Remotes") or RS:WaitForChild("Remotes", 5)
-if not REMOTES then
+local remotes = RS:FindFirstChild("Remotes") or RS:WaitForChild("Remotes", 5)
+local vehicleInput = remotes and (remotes:FindFirstChild("VehicleInput") or remotes:WaitForChild("VehicleInput", 5))
+
+if not remotes then
 	warn("[VehicleController] Remotes ontbreekt")
-	return
-end
-
-local VEHICLE_INPUT = REMOTES:FindFirstChild("VehicleInput") or REMOTES:WaitForChild("VehicleInput", 5)
-if not VEHICLE_INPUT then
+elseif not vehicleInput then
 	warn("[VehicleController] VehicleInput ontbreekt")
-	return
 end
 
 local FWD_SPEED = 60
 local TURN_RATE = 2
 
-local function resolveVehicle(player)
-	local character = player.Character
-	if not character then
+local function cleanupExternalWelds(model)
+	if not model then
 		return
 	end
 
-	local humanoid = character:FindFirstChildOfClass("Humanoid")
-	if not humanoid then
-		return
+	for _, descendant in ipairs(model:GetDescendants()) do
+		if descendant:IsA("WeldConstraint") then
+			local part0, part1 = descendant.Part0, descendant.Part1
+			if (part0 and not model:IsAncestorOf(part0)) or (part1 and not model:IsAncestorOf(part1)) then
+				descendant.Enabled = false
+			end
+		end
 	end
-
-	local seatPart = humanoid.SeatPart
-	if not seatPart or seatPart.Occupant ~= humanoid then
-		return
-	end
-
-	local vehicle = seatPart:FindFirstAncestorOfClass("Model")
-	return vehicle, seatPart
 end
+
+local function unanchorAssembly(model)
+	if not model then
+		return
+	end
+
+	for _, descendant in ipairs(model:GetDescendants()) do
+		if descendant:IsA("BasePart") then
+			descendant.Anchored = false
+		end
+	end
+end
+
+local function getRootPart(model, seat)
+	if not model then
+		return nil
+	end
+
+	local root = model.PrimaryPart
+	if root and root:IsA("BasePart") then
+		return root
+	end
+
+	if seat and seat:IsA("BasePart") then
+		return seat
+	end
+
+	for _, descendant in ipairs(model:GetDescendants()) do
+		if descendant:IsA("BasePart") then
+			return descendant
+		end
+	end
+
+	return nil
+end
+
+local activeSeats = {}
+local trackedSeats = {}
 
 local function applyInput(root, throttle, steer)
 	if not root then
@@ -41,11 +74,11 @@ local function applyInput(root, throttle, steer)
 	end
 
 	if typeof(throttle) ~= "number" then
-		throttle = 0
+		throttle = tonumber(throttle) or 0
 	end
 
 	if typeof(steer) ~= "number" then
-		steer = 0
+		steer = tonumber(steer) or 0
 	end
 
 	throttle = math.clamp(throttle, -1, 1)
@@ -61,34 +94,62 @@ local function applyInput(root, throttle, steer)
 	end
 end
 
-VEHICLE_INPUT.OnServerEvent:Connect(function(player, throttle, steer)
-	local vehicle, seatPart = resolveVehicle(player)
+local function deactivateSeat(seat, clearOwner)
+	local state = activeSeats[seat]
+	if not state then
+		return
+	end
+
+	if clearOwner and state.root and state.root.Parent then
+		local success, err = pcall(function()
+			state.root:SetNetworkOwner(nil)
+		end)
+		if not success then
+			warn("[VehicleController] Failed to clear network owner: ", err)
+		end
+	end
+
+	activeSeats[seat] = nil
+end
+
+local function activateSeat(seat, player)
+	if not seat or not player then
+		return
+	end
+
+	local vehicle = seat:FindFirstAncestorOfClass("Model")
 	if not vehicle then
 		return
 	end
 
-	local model = vehicle
-	local root = (model and model.PrimaryPart) or seatPart
+	local root = getRootPart(vehicle, seat)
 	if not root then
 		return
 	end
 
+	local state = activeSeats[seat]
+	if not state then
+		state = {}
+		activeSeats[seat] = state
+	end
+
+	state.player = player
+	state.vehicle = vehicle
+	state.root = root
+	state.usesVehicleSeat = seat:IsA("VehicleSeat")
+
+	if state.usesVehicleSeat then
+		state.throttle = seat.Throttle
+		state.steer = seat.Steer
+	else
+		state.throttle = 0
+		state.steer = 0
+	end
+
+	cleanupExternalWelds(vehicle)
+	unanchorAssembly(vehicle)
+
 	if root.CanSetNetworkOwnership then
-		for _, descendant in ipairs(model:GetDescendants()) do
-			if descendant:IsA("WeldConstraint") then
-				local part0, part1 = descendant.Part0, descendant.Part1
-				if (part0 and not model:IsAncestorOf(part0)) or (part1 and not model:IsAncestorOf(part1)) then
-					descendant.Enabled = false
-				end
-			end
-		end
-
-		for _, descendant in ipairs(model:GetDescendants()) do
-			if descendant:IsA("BasePart") then
-				descendant.Anchored = false
-			end
-		end
-
 		local canSet, reason = root:CanSetNetworkOwnership()
 		if not canSet then
 			warn("[VehicleController] CanSetNetworkOwnership=false: ", reason)
@@ -99,6 +160,148 @@ VEHICLE_INPUT.OnServerEvent:Connect(function(player, throttle, steer)
 			end
 		end
 	end
+end
 
-	applyInput(root, throttle, steer)
+local function updateSeatInputFromSeat(seat)
+	local state = activeSeats[seat]
+	if not state or not state.usesVehicleSeat then
+		return
+	end
+
+	state.throttle = math.clamp(seat.Throttle or 0, -1, 1)
+	state.steer = math.clamp(seat.Steer or 0, -1, 1)
+end
+
+local function handleOccupantChanged(seat)
+	local occupant = seat.Occupant
+	if occupant and occupant.Parent then
+		local player = Players:GetPlayerFromCharacter(occupant.Parent)
+		if player then
+			activateSeat(seat, player)
+			if seat:IsA("VehicleSeat") then
+				updateSeatInputFromSeat(seat)
+			end
+			return
+		end
+	end
+
+	deactivateSeat(seat, true)
+end
+
+local function resolveSeatForPlayer(player)
+	local character = player.Character
+	if not character then
+		return nil
+	end
+
+	local humanoid = character:FindFirstChildOfClass("Humanoid")
+	if not humanoid then
+		return nil
+	end
+
+	local seatPart = humanoid.SeatPart
+	if not seatPart or seatPart.Occupant ~= humanoid then
+		return nil
+	end
+
+	return seatPart
+end
+
+local function updateSeatInputFromRemote(player, throttle, steer)
+	local seat = resolveSeatForPlayer(player)
+	if not seat or seat:IsA("VehicleSeat") then
+		return
+	end
+
+	throttle = tonumber(throttle) or 0
+	steer = tonumber(steer) or 0
+
+	throttle = math.clamp(throttle, -1, 1)
+	steer = math.clamp(steer, -1, 1)
+
+	local state = activeSeats[seat]
+	if not state or state.player ~= player then
+		activateSeat(seat, player)
+		state = activeSeats[seat]
+	end
+
+	if not state then
+		return
+	end
+
+	state.throttle = throttle
+	state.steer = steer
+end
+
+local function disconnectSeat(seat)
+	local tracked = trackedSeats[seat]
+	if tracked then
+		for _, connection in ipairs(tracked.connections) do
+			connection:Disconnect()
+		end
+	end
+	trackedSeats[seat] = nil
+	deactivateSeat(seat, true)
+end
+
+local function trackSeat(seat)
+	if trackedSeats[seat] then
+		return
+	end
+
+	local tracked = {
+		connections = {}
+	}
+	trackedSeats[seat] = tracked
+
+	local function onOccupantChanged()
+		handleOccupantChanged(seat)
+	end
+
+	tracked.connections[#tracked.connections + 1] = seat:GetPropertyChangedSignal("Occupant"):Connect(onOccupantChanged)
+
+	if seat:IsA("VehicleSeat") then
+		local function onInputChanged()
+			updateSeatInputFromSeat(seat)
+		end
+
+		tracked.connections[#tracked.connections + 1] = seat:GetPropertyChangedSignal("Throttle"):Connect(onInputChanged)
+		tracked.connections[#tracked.connections + 1] = seat:GetPropertyChangedSignal("Steer"):Connect(onInputChanged)
+	end
+
+	tracked.connections[#tracked.connections + 1] = seat.AncestryChanged:Connect(function(_, parent)
+		if not parent then
+			disconnectSeat(seat)
+		end
+	end)
+
+	onOccupantChanged()
+end
+
+for _, descendant in ipairs(Workspace:GetDescendants()) do
+	if descendant:IsA("Seat") or descendant:IsA("VehicleSeat") then
+		trackSeat(descendant)
+	end
+end
+
+Workspace.DescendantAdded:Connect(function(descendant)
+	if descendant:IsA("Seat") or descendant:IsA("VehicleSeat") then
+		trackSeat(descendant)
+	end
 end)
+
+RunService.Heartbeat:Connect(function()
+	for seat, state in pairs(activeSeats) do
+		if not seat.Parent or not state.root or not state.root.Parent then
+			deactivateSeat(seat, true)
+		else
+			applyInput(state.root, state.throttle or 0, state.steer or 0)
+		end
+	end
+end)
+
+if vehicleInput then
+	vehicleInput.OnServerEvent:Connect(function(player, throttle, steer)
+		updateSeatInputFromRemote(player, throttle, steer)
+	end)
+end

--- a/src/ServerScriptService/VehicleController.server.lua.server.lua
+++ b/src/ServerScriptService/VehicleController.server.lua.server.lua
@@ -1,6 +1,16 @@
 local RS = game:GetService("ReplicatedStorage")
-local REMOTES = RS:WaitForChild("Remotes")
-local VEHICLE_INPUT = REMOTES:WaitForChild("VehicleInput")
+
+local REMOTES = RS:FindFirstChild("Remotes") or RS:WaitForChild("Remotes", 5)
+if not REMOTES then
+	warn("[VehicleController] Remotes ontbreekt")
+	return
+end
+
+local VEHICLE_INPUT = REMOTES:FindFirstChild("VehicleInput") or REMOTES:WaitForChild("VehicleInput", 5)
+if not VEHICLE_INPUT then
+	warn("[VehicleController] VehicleInput ontbreekt")
+	return
+end
 
 local FWD_SPEED = 60
 local TURN_RATE = 2

--- a/src/ServerScriptService/VehicleController.server.lua.server.lua
+++ b/src/ServerScriptService/VehicleController.server.lua.server.lua
@@ -1,0 +1,69 @@
+local RS = game:GetService("ReplicatedStorage")
+local REMOTES = RS:WaitForChild("Remotes")
+local VEHICLE_INPUT = REMOTES:WaitForChild("VehicleInput")
+
+local FWD_SPEED = 60
+local TURN_RATE = 2
+
+local function resolveVehicle(player)
+	local character = player.Character
+	if not character then
+		return
+	end
+
+	local humanoid = character:FindFirstChildOfClass("Humanoid")
+	if not humanoid then
+		return
+	end
+
+	local seatPart = humanoid.SeatPart
+	if not seatPart or seatPart.Occupant ~= humanoid then
+		return
+	end
+
+	local vehicle = seatPart:FindFirstAncestorOfClass("Model")
+	return vehicle, seatPart
+end
+
+local function applyInput(root, throttle, steer)
+	if not root then
+		return
+	end
+
+	if typeof(throttle) ~= "number" then
+		throttle = 0
+	end
+
+	if typeof(steer) ~= "number" then
+		steer = 0
+	end
+
+	throttle = math.clamp(throttle, -1, 1)
+	steer = math.clamp(steer, -1, 1)
+
+	local currentVelocity = root.AssemblyLinearVelocity
+	local forward = root.CFrame.LookVector * (FWD_SPEED * throttle)
+	root.AssemblyLinearVelocity = Vector3.new(forward.X, currentVelocity.Y, forward.Z)
+
+	local mass = root.AssemblyMass
+	if mass > 0 then
+		root:ApplyAngularImpulse(Vector3.new(0, steer * TURN_RATE * mass, 0))
+	end
+end
+
+VEHICLE_INPUT.OnServerEvent:Connect(function(player, throttle, steer)
+	local vehicle, seatPart = resolveVehicle(player)
+	if not vehicle then
+		return
+	end
+
+	local root = vehicle.PrimaryPart or seatPart
+	if root and root.CanSetNetworkOwnership then
+		local currentOwner = root:GetNetworkOwner()
+		if currentOwner ~= player then
+			root:SetNetworkOwner(player)
+		end
+	end
+
+	applyInput(root, throttle, steer)
+end)

--- a/src/StarterPlayer/StarterPlayerScripts/CameraScript.client.lua.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/CameraScript.client.lua.client.lua
@@ -50,14 +50,13 @@ local cineActive       = false
 local pendingSnap      = nil -- {pos=Vector3, look=Vector3, fov=number}
 local snapDelayFrames  = 0   -- wacht x frames voor we de snap zetten (tegen dubbele writes)
 local controllerBound  = false
-local PRIORITY_FINAL   = Enum.RenderPriority.Last.Value
-local renderStep
+local onRender
 
 local function bindControllerLoop()
-        if controllerBound or not renderStep then return end
-        print("[CameraController] Binding LightRaceCam; controllerBound=", controllerBound, "cineActive=", cineActive)
-        RunService:BindToRenderStep("LightRaceCam", PRIORITY_FINAL, renderStep)
-        controllerBound = true
+	if controllerBound or not onRender then return end
+	print("[CameraController] Binding LightRaceCam; controllerBound=", controllerBound, "cineActive=", cineActive)
+	RunService:BindToRenderStep("LightRaceCam", Enum.RenderPriority.Last.Value, onRender)
+	controllerBound = true
 end
 
 local function unbindControllerLoop()
@@ -307,15 +306,15 @@ local function renderLobby()
 end
 
 -- ===== Render loop (single writer) =====
-renderStep = function(_dt)
-        if not controllerEnabled then return end
-        if cineActive then return end
+onRender = function(_dt)
+	if workspace.CurrentCamera.CameraType ~= Enum.CameraType.Scriptable then
+		workspace.CurrentCamera.CameraType = Enum.CameraType.Scriptable
+	end
 
-        if cam.CameraType ~= Enum.CameraType.Scriptable then
-                cam.CameraType = Enum.CameraType.Scriptable
-        end
+	if not controllerEnabled then return end
+	if cineActive then return end
 
-        if pendingSnap then
+	if pendingSnap then
                 if snapDelayFrames > 0 then
                         snapDelayFrames -= 1
                         return

--- a/src/StarterPlayer/StarterPlayerScripts/CameraScript.client.lua.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/CameraScript.client.lua.client.lua
@@ -1,351 +1,61 @@
--- CameraController.client.lua — centrale chasecamera met CameraGuard mutex.
--- Houdt de camera exclusief vast zodat slechts één script per frame schrijft.
--- Front/back chase wisselbaar met F, FPV met V.
+-- File: StarterPlayer/StarterPlayerScripts/CameraScript.client.lua
+-- Lobby = third-person (achter/boven). Zittend (in-game) = first-person langs Seat-front.
+-- Eén camera-eigenaar, draait als allerlaatste (geen jitter/flip).
 
-local Players    = game:GetService("Players")
+local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
-local Workspace  = game:GetService("Workspace")
-local UIS        = game:GetService("UserInputService")
-local RS         = game:GetService("ReplicatedStorage")
 
-local player = Players.LocalPlayer
-local cam    = Workspace.CurrentCamera
-cam.CameraType    = Enum.CameraType.Scriptable
-cam.CameraSubject = nil
+local lp = Players.LocalPlayer
+local currentSeat -- Seat of VehicleSeat
 
-local CameraGuard = require(script.Parent:WaitForChild("CameraGuard"))
-local GUARD_ID = "CameraController"
-
--- ===== Duplicate guard =====
-pcall(function() RunService:UnbindFromRenderStep("LightRaceCam") end)
-do
-        local token = cam:FindFirstChild("LightRaceCamActive")
-	if token then
-		warn("[CameraController] duplicate instance; aborting")
-		return
-	else
-		Instance.new("BoolValue", cam).Name = "LightRaceCamActive"
-	end
-end
-
-local function SetCam(cf, fov, reason)
-        if not CameraGuard:tryAcquire(GUARD_ID, reason) then
-                return false
-        end
-        cam.CameraType = Enum.CameraType.Scriptable
-        cam.CameraSubject = nil
-        if fov then cam.FieldOfView = fov end
-        cam.CFrame = cf
-        CameraGuard:release(GUARD_ID)
-        return true
-end
-
--- ===== Bus / cinematic handshake =====
-local bus    = RS:FindFirstChild("ClientBus") or Instance.new("Folder", RS)
-bus.Name     = "ClientBus"; bus.Parent = RS
-local CamEvt = bus:FindFirstChild("CamCinematic") or Instance.new("BindableEvent", bus)
-CamEvt.Name  = "CamCinematic"; CamEvt.Parent = bus
-
-local cineActive       = false
-local pendingSnap      = nil -- {pos=Vector3, look=Vector3, fov=number}
-local snapDelayFrames  = 0   -- wacht x frames voor we de snap zetten (tegen dubbele writes)
-local controllerBound  = false
-local onRender
-
-local function bindControllerLoop()
-	if controllerBound or not onRender then return end
-	print("[CameraController] Binding LightRaceCam; controllerBound=", controllerBound, "cineActive=", cineActive)
-	RunService:BindToRenderStep("LightRaceCam", Enum.RenderPriority.Last.Value, onRender)
-	controllerBound = true
-end
-
-local function unbindControllerLoop()
-        if not controllerBound then return end
-        print("[CameraController] Unbinding LightRaceCam; controllerBound=", controllerBound, "cineActive=", cineActive)
-        RunService:UnbindFromRenderStep("LightRaceCam")
-        controllerBound = false
-end
-
-CamEvt.Event:Connect(function(payload)
-        if not payload or not payload.type then return end
-        if payload.type == "start" then
-                unbindControllerLoop()
-                cineActive = true
-        elseif payload.type == "stop" then
-                cineActive = false
-                -- seed voor eerste chase-frame na cinematic
-                local cycle = nil
-                for _,m in ipairs(Workspace:GetChildren()) do
-                        if m:IsA("Model") and m.Name == (player.Name .. "_Cycle") then cycle = m; break end
-                end
-		local pos, look, fov
-		if cycle and cycle.PrimaryPart then
-			local ppCF = cycle.PrimaryPart.CFrame
-			local fwd, right = ppCF.LookVector, ppCF.RightVector
-			local up = Vector3.new(0,1,0)
-			-- standaard seed (achter-view); wordt zo nodig front gezet door renderChase
-			local CHASE_BACK, CHASE_SIDE, CHASE_UP = 12.0, 3.2, 9.0
-			local CHASE_LOOK_AHEAD = 14
-			local base = ppCF.Position
-			pos  = base - fwd*CHASE_BACK + right*CHASE_SIDE + up*CHASE_UP
-			look = base + fwd*CHASE_LOOK_AHEAD + up*(CHASE_UP*0.6)
-			fov  = 70
+local function onChar(char)
+	local hum = char:WaitForChild("Humanoid")
+	hum.Seated:Connect(function(isSeated, seatPart)
+		if isSeated and seatPart and seatPart:IsA("Seat") then
+			currentSeat = seatPart
+			hum.AutoRotate = false
+			hum.Sit = true
 		else
-			local snapPos = payload.pos or Vector3.new()
-			local yaw     = payload.yaw or 0
-			local fwd = (CFrame.Angles(0, yaw, 0)).LookVector
-			local right = Vector3.new(fwd.Z,0,-fwd.X)
-			local up = Vector3.new(0,1,0)
-			local CHASE_BACK, CHASE_SIDE, CHASE_UP = 12.0, 3.2, 9.0
-			local CHASE_LOOK_AHEAD = 14
-			pos  = snapPos - fwd*CHASE_BACK + right*CHASE_SIDE + up*CHASE_UP
-			look = snapPos + fwd*CHASE_LOOK_AHEAD + up*(CHASE_UP*0.6)
-			fov  = 70
+			currentSeat = nil
+			hum.AutoRotate = true
 		end
-                pendingSnap = {pos = pos, look = look, fov = fov}
-                snapDelayFrames = 2
-                bindControllerLoop()
-        end
-end)
-
--- ===== Round flow (force FPV tijdens countdown) =====
-local RoundEvent      = RS:FindFirstChild("RoundEvent")
-local RoundActiveVal  = RS:WaitForChild("RoundActive")
-local forceFPV        = true
-
-if RoundEvent then
-	RoundEvent.OnClientEvent:Connect(function(kind)
-		if kind == "countdown" then forceFPV = true end
-		if kind == "go"        then forceFPV = false end
 	end)
 end
 
--- ===== Manual toggles =====
-local useCockpitManual = false
-local controllerEnabled = true   -- K: toggelt onze writer
-local frontChase = false         -- F: wissel front/back chase (default: achtervolg-view)
-local resetSmoothing             -- forward declare zodat we 'm vanuit toggles kunnen aanroepen
-UIS.InputBegan:Connect(function(input, gp)
-	if gp then return end
-	if input.KeyCode == Enum.KeyCode.V then
-		useCockpitManual = not useCockpitManual
-	elseif input.KeyCode == Enum.KeyCode.K then
-		controllerEnabled = not controllerEnabled
-		print("[CamGuard] controllerEnabled=", controllerEnabled)
-        elseif input.KeyCode == Enum.KeyCode.F then
-                frontChase = not frontChase
-                if resetSmoothing then resetSmoothing() end -- voorkom smoothing-blend tussen front/back
-                print("[Cam] chase mode =", frontChase and "FRONT" or "BACK")
-        end
+if lp.Character then onChar(lp.Character) end
+lp.CharacterAdded:Connect(onChar)
+
+local function thirdPerson(char)
+	local hrp = char and char:FindFirstChild("HumanoidRootPart")
+	if not hrp then return end
+	local pivot = hrp.CFrame
+	local eye = (pivot * CFrame.new(0, 6, 12)).Position
+	return CFrame.new(eye, pivot.Position)
+end
+
+local function firstPersonSeat(seat)
+	local seatCF = seat.CFrame
+	local eye = (seatCF * CFrame.new(0, 2.2, 0.1)).Position
+	return CFrame.new(eye, eye + seatCF.LookVector)
+end
+
+RunService:BindToRenderStep("LightRaceCam", Enum.RenderPriority.Last.Value, function()
+	local cam = workspace.CurrentCamera
+	if cam.CameraType ~= Enum.CameraType.Scriptable then
+		cam.CameraType = Enum.CameraType.Scriptable
+	end
+
+	local pg = lp:FindFirstChildOfClass("PlayerGui")
+	local inLobby = pg and pg:FindFirstChild("LobbyUI") ~= nil
+
+	if inLobby then
+		local cf = thirdPerson(lp.Character)
+		if cf then cam.CFrame = cf; return end
+	elseif currentSeat and currentSeat.Parent then
+		cam.CFrame = firstPersonSeat(currentSeat)
+		return
+	end
+
+	local cf = thirdPerson(lp.Character)
+	if cf then cam.CFrame = cf end
 end)
-
--- ===== Tuning =====
--- BACK-CHASE offsets
-local CHASE_BACK, CHASE_SIDE, CHASE_UP  = 12.0, 3.2, 9.0
-local CHASE_LOOK_AHEAD, CHASE_FOV       = 14, 70
-
--- FRONT-CHASE offsets (camera vóór de cycle, kijkend naar de cycle)
-local FRONT_AHEAD, FRONT_SIDE, FRONT_UP = 11.0, 0.0, 9.0
--- Je kunt FRONT_SIDE bv. 1.5 zetten voor een schuin-front effect
-
-local ANTICLIP_PUSH                     = 0.6
--- FPV
-local FPV_FOV, FPV_HEAD_BACK, FPV_AHEAD = 80, 0.12, 11
-local FPV_SEAT_Y, FPV_SEAT_Z            = 2.1, -0.10
--- ===== Helpers =====
-local function getCycle()
-        for _,m in ipairs(Workspace:GetChildren()) do
-                if m:IsA("Model") and m.Name == (player.Name .. "_Cycle") then
-                        return m
-		end
-	end
-end
-
-local function myWallsFolder()
-	return Workspace:FindFirstChild(player.Name .. "_Walls")
-end
-
-local function raycast_exclude(fromPos, toPos, exclude)
-	local params = RaycastParams.new()
-	params.FilterType = Enum.RaycastFilterType.Exclude
-	params.FilterDescendantsInstances = exclude or {}
-	return Workspace:Raycast(fromPos, (toPos - fromPos), params)
-end
-
--- ===== State =====
-local lastCycle   = nil
-local clipArmed   = false
-
-resetSmoothing = function()
-        clipArmed = false
-end
-Players.LocalPlayer.CharacterAdded:Connect(resetSmoothing)
-RoundActiveVal:GetPropertyChangedSignal("Value"):Connect(resetSmoothing)
-
--- ===== Chase compute (back & front) =====
-local function computeChaseBack(baseCF, cycle)
-	local pos   = baseCF.Position
-	local fwd   = baseCF.LookVector
-	local right = baseCF.RightVector
-	local up    = Vector3.new(0,1,0)
-
-	local wantPos  = pos - fwd*CHASE_BACK + right*CHASE_SIDE + up*CHASE_UP
-	local wantLook = pos + fwd*CHASE_LOOK_AHEAD + up*(CHASE_UP*0.6)
-
-	-- Anti-clip: negeer eigen cycle/character/walls
-	local exclude = {cycle, player.Character}
-	local walls = myWallsFolder(); if walls then table.insert(exclude, walls) end
-	local target = pos + up*(CHASE_UP*0.6)
-	local hit = raycast_exclude(target, wantPos, exclude)
-	if hit then
-		local dir = (wantPos - target).Unit
-		wantPos = hit.Position - dir * ANTICLIP_PUSH
-		clipArmed = true
-	else
-		if clipArmed then
-			local extra = raycast_exclude(target, wantPos + (wantPos - target).Unit * 0.25, exclude)
-			if extra then
-				local dir = (wantPos - target).Unit
-				wantPos = extra.Position - dir * ANTICLIP_PUSH
-			else
-				clipArmed = false
-			end
-		end
-	end
-	return wantPos, wantLook
-end
-
-local function computeChaseFront(baseCF, cycle)
-	local pos   = baseCF.Position
-	local fwd   = baseCF.LookVector
-	local right = baseCF.RightVector
-	local up    = Vector3.new(0,1,0)
-
-	-- camera vóór de cycle, kijkend naar de cycle
-	local wantPos  = pos + fwd*FRONT_AHEAD + right*FRONT_SIDE + up*FRONT_UP
-	local wantLook = pos + up*(FRONT_UP*0.6)
-
-	-- Anti-clip: negeer eigen cycle/character/walls
-	local exclude = {cycle, player.Character}
-	local walls = myWallsFolder(); if walls then table.insert(exclude, walls) end
-	local target = wantLook -- we kijken naar de cycle; cast vanaf target naar camera
-	local hit = raycast_exclude(target, wantPos, exclude)
-	if hit then
-		local dir = (wantPos - target).Unit
-		wantPos = hit.Position - dir * ANTICLIP_PUSH
-		clipArmed = true
-	else
-		if clipArmed then
-			local extra = raycast_exclude(target, wantPos + (wantPos - target).Unit * 0.25, exclude)
-			if extra then
-				local dir = (wantPos - target).Unit
-				wantPos = extra.Position - dir * ANTICLIP_PUSH
-			else
-				clipArmed = false
-			end
-		end
-	end
-	return wantPos, wantLook
-end
-
--- ===== Renderers =====
-local function renderChase(cycle)
-        local pp = cycle.PrimaryPart; if not pp then return end
-        local baseCF = pp.CFrame
-        local wantPos, wantLook
-	if frontChase then
-		wantPos, wantLook = computeChaseFront(baseCF, cycle)
-	else
-		wantPos, wantLook = computeChaseBack(baseCF, cycle)
-	end
-
-        SetCam(CFrame.new(wantPos, wantLook), CHASE_FOV, frontChase and "chase_front" or "chase_back")
-end
-
-local function renderFPV(cycle)
-	local char = player.Character
-        local head = char and char:FindFirstChild("Head")
-        local eye, ahead
-
-        if head and head:IsA("BasePart") then
-                local headCF = head.CFrame
-                eye   = (headCF * CFrame.new(0, 0, FPV_HEAD_BACK)).Position
-                ahead = eye + headCF.LookVector * FPV_AHEAD
-        else
-                local pp = cycle.PrimaryPart
-                local baseCF = pp and pp.CFrame or CFrame.new()
-                eye   = (baseCF * CFrame.new(0, FPV_SEAT_Y, FPV_SEAT_Z)).Position
-                ahead = eye + baseCF.LookVector * FPV_AHEAD
-        end
-
-	-- mini anti-clip vlak voor de cam
-	local hit = raycast_exclude(eye, eye + (ahead - eye).Unit * 0.7, {cycle, char})
-	if hit then eye = eye + (ahead - eye).Unit * 0.35 end
-
-	SetCam(CFrame.new(eye, ahead), FPV_FOV, "fpv")
-	resetSmoothing()
-end
-
-local function renderLobby()
-        local char = player.Character
-        local root = char and char:FindFirstChild("HumanoidRootPart")
-        if not root then return end
-
-        local forward = root.CFrame.LookVector
-        forward = Vector3.new(forward.X, 0, forward.Z)
-        if forward.Magnitude < 1e-4 then
-                forward = Vector3.new(0, 0, -1)
-        else
-                forward = forward.Unit
-        end
-
-        local rootPos = root.Position
-        local eye = rootPos - forward * 14 + Vector3.new(0, 8, 0)
-        local look = rootPos + forward * 6 + Vector3.new(0, 2, 0)
-        SetCam(CFrame.new(eye, look), 70, "lobby")
-end
-
--- ===== Render loop (single writer) =====
-onRender = function(_dt)
-	if workspace.CurrentCamera.CameraType ~= Enum.CameraType.Scriptable then
-		workspace.CurrentCamera.CameraType = Enum.CameraType.Scriptable
-	end
-
-	if not controllerEnabled then return end
-	if cineActive then return end
-
-	if pendingSnap then
-                if snapDelayFrames > 0 then
-                        snapDelayFrames -= 1
-                        return
-                end
-                if SetCam(CFrame.new(pendingSnap.pos, pendingSnap.look), pendingSnap.fov or CHASE_FOV, "snap") then
-                        resetSmoothing()
-                        pendingSnap = nil
-                end
-                return
-        end
-
-        if not RoundActiveVal.Value then
-                renderLobby()
-                return
-        end
-
-        local cycle = getCycle()
-        if not cycle or not cycle.PrimaryPart then
-                return
-        end
-
-        if cycle ~= lastCycle then
-                lastCycle = cycle
-                resetSmoothing()
-        end
-
-        if (forceFPV or useCockpitManual) then
-                renderFPV(cycle)
-        else
-                renderChase(cycle)
-        end
-end
-
-bindControllerLoop()

--- a/src/StarterPlayer/StarterPlayerScripts/LobbyUI.client.lua.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/LobbyUI.client.lua.client.lua
@@ -49,8 +49,8 @@ end)
 local UIS = game:GetService("UserInputService")
 UIS.InputBegan:Connect(function(i,gp)
 	if gp then return end
-	if i.KeyCode == Enum.KeyCode.E then btnReady:Activate() end
-	if i.KeyCode == Enum.KeyCode.Y then btnStart:Activate() end
+	if i.KeyCode == Enum.KeyCode.E then btnReady:Activated() end
+	if i.KeyCode == Enum.KeyCode.Y then btnStart:Activated() end
 end)
 
 LobbyEvent.OnClientEvent:Connect(function(payload)

--- a/src/StarterPlayer/StarterPlayerScripts/SeatInput.client.lua.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/SeatInput.client.lua.client.lua
@@ -1,0 +1,121 @@
+local Players = game:GetService("Players")
+local CAS = game:GetService("ContextActionService")
+local RS = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+
+local localPlayer = Players.LocalPlayer
+local remotes = RS:WaitForChild("Remotes")
+local vehicleInput = remotes:WaitForChild("VehicleInput")
+
+local controls do
+	local playerModule = localPlayer:WaitForChild("PlayerScripts"):FindFirstChild("PlayerModule")
+		or localPlayer.PlayerScripts:WaitForChild("PlayerModule", 3)
+
+	if playerModule then
+		local success, module = pcall(require, playerModule)
+		if success and module.GetControls then
+			controls = module:GetControls()
+		end
+	end
+end
+
+local driving = false
+local throttle = 0
+local steer = 0
+local renderConnection
+
+local function sendInput()
+	if driving then
+		vehicleInput:FireServer(throttle, steer)
+	end
+end
+
+local function drive(_, state, input)
+	local keyCode = input.KeyCode
+	local down = state == Enum.UserInputState.Begin or state == Enum.UserInputState.Change
+
+	if keyCode == Enum.KeyCode.W then
+		throttle = down and 1 or (throttle == 1 and 0 or throttle)
+	elseif keyCode == Enum.KeyCode.S then
+		throttle = down and -1 or (throttle == -1 and 0 or throttle)
+	elseif keyCode == Enum.KeyCode.A then
+		steer = down and -1 or (steer == -1 and 0 or steer)
+	elseif keyCode == Enum.KeyCode.D then
+		steer = down and 1 or (steer == 1 and 0 or steer)
+	end
+
+	sendInput()
+
+	return Enum.ContextActionResult.Sink
+end
+
+local function bindDriving()
+	if driving then
+		return
+	end
+
+	if controls and controls.Disable then
+		controls:Disable()
+	end
+
+	CAS:BindActionAtPriority("DriveSeat", drive, false, 3000, Enum.KeyCode.W, Enum.KeyCode.A, Enum.KeyCode.S, Enum.KeyCode.D)
+
+	renderConnection = RunService.RenderStepped:Connect(sendInput)
+	driving = true
+	sendInput()
+end
+
+local function unbindDriving()
+	if not driving then
+		return
+	end
+
+	driving = false
+	throttle = 0
+	steer = 0
+
+	CAS:UnbindAction("DriveSeat")
+
+	if renderConnection then
+		renderConnection:Disconnect()
+		renderConnection = nil
+	end
+
+	if controls and controls.Enable then
+		controls:Enable()
+	end
+
+	vehicleInput:FireServer(0, 0)
+end
+
+local function handleSeatChange(humanoid)
+	humanoid.Seated:Connect(function(isSeated, seatPart)
+		if isSeated and seatPart and (seatPart:IsA("Seat") or seatPart:IsA("VehicleSeat")) then
+			humanoid.AutoRotate = false
+			humanoid.Sit = true
+			bindDriving()
+		else
+			humanoid.AutoRotate = true
+			unbindDriving()
+		end
+	end)
+
+	humanoid.Died:Connect(function()
+		humanoid.AutoRotate = true
+		unbindDriving()
+	end)
+end
+
+local function onCharacter(character)
+	unbindDriving()
+
+	local humanoid = character:FindFirstChildOfClass("Humanoid") or character:WaitForChild("Humanoid")
+	humanoid.AutoRotate = true
+	handleSeatChange(humanoid)
+end
+
+if localPlayer.Character then
+	onCharacter(localPlayer.Character)
+end
+
+localPlayer.CharacterAdded:Connect(onCharacter)

--- a/src/StarterPlayer/StarterPlayerScripts/SeatInput.client.lua.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/SeatInput.client.lua.client.lua
@@ -4,8 +4,18 @@ local RS = game:GetService("ReplicatedStorage")
 local RunService = game:GetService("RunService")
 
 local localPlayer = Players.LocalPlayer
-local remotes = RS:WaitForChild("Remotes")
-local vehicleInput = remotes:WaitForChild("VehicleInput")
+
+local remotes = RS:FindFirstChild("Remotes") or RS:WaitForChild("Remotes", 5)
+if not remotes then
+	warn("[SeatInput] Remotes folder ontbreekt")
+	return
+end
+
+local vehicleInput = remotes:FindFirstChild("VehicleInput") or remotes:WaitForChild("VehicleInput", 5)
+if not vehicleInput then
+	warn("[SeatInput] VehicleInput ontbreekt")
+	return
+end
 
 local controls do
 	local playerModule = localPlayer:WaitForChild("PlayerScripts"):FindFirstChild("PlayerModule")


### PR DESCRIPTION
## Summary
- add a VehicleInput RemoteEvent in ReplicatedStorage for driving data
- capture seat state on the client to disable default controls and stream throttle/steer to the server
- apply incoming vehicle input on the server while assigning network ownership to the driver

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8783d4350832294dbc0922aee07d8